### PR TITLE
add goreleaser config and script to create releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,8 @@ max_line_length = 0
 indent_style = space
 indent_size = 2
 max_line_length = 0
+
+[*.yml]
+indent_style = space
+indent_size = 2
+max_line_length = 0

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ website/vendor
 
 *.lock.hcl
 terraform-provider-bunny
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-X github.com/simplesurance/terraform-provider-bunny/internal/provider.Version={{.Version}} -X github.com/simplesurance/terraform-provider-bunny/internal/provider.Commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--local-user"
+      - "{{ .Env:GPG_RELEASE_SIGN_KEY_ID }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  draft: true
+changelog:
+  skip: false

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ make sweep
 make docs
 ```
 
+### Creating a Release
+
+1. Ensure the entry for the version in CHANGELOG.md is uptodate. \
+   (Keep the `(Unreleased)` marker.)
+2. Run:  
+
+    ```sh
+    scripts/create-release.sh VERSION
+    ``` 
+
+    To finalize the CHANGELOG.md file, create a signed git tag, build the
+    release binaries create a GitHub draft release with the binaries.
+
+3. Publish the draft release on github.
+
 
 ## Known Issues
 - When destroying a non-existing pull-zone, the operation fails. It should

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ make docs
 ### Missing Features
 
 - `terraform import` support
-- Edge Rules
-- Custom Hostnames
-- Certificates
-- Write support is missing for the following Pull Zone fields:
-  - `blocked_referrers`
-  - `access_control_origin_header_extensions`
-  - all `enable_geo_zone_*` fields
-- The following Pull Zone fields are unsupported:
+- unsupported Pull Zone features:
+  - Edge Rules
+  - Custom Hostnames
+  - Certificates
   - `cache_error_response`
   - `enable_query_string_ordering`
+- Pull Zone fields with missing write support:
+    - `blocked_referrers`
+    - `access_control_origin_header_extensions`
+    - all `enable_geo_zone_*` fields
 
 ## Status
 

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+changelog_file="CHANGELOG.md"
+gpg_sign_key_id="0xC8B381683DBCEDFE"
+
+err() {
+	echo "ERR:" "$@" >&2
+}
+
+fatal() {
+	err "$@"
+	exit 1
+}
+
+
+set_unreleased_date() (
+	if ! grep -qxi "^## $version (Unreleased)" "$changelog_file";then
+		fatal "unreleased entry for ver $version missing in $changelog_file"
+	fi
+
+	ver_date="$(env LANG=en_US.UTF-8 date '+%B %d, %Y')"
+
+	sed  -i "s/## $version (Unreleased)/## $version ($ver_date)/g" "$changelog_file"
+)
+
+add_new_release_line() (
+	next_ver="$(echo "${version}" | awk -F. -v OFS=. '{$NF++;print}')"
+	echo -e "## $next_ver (Unreleased)\n\n$(cat "$changelog_file")" > "$changelog_file"
+)
+
+git_tag_exists() {
+	git describe --abbrev=0 --match="$tag" --tags &>/dev/null
+}
+
+create_git_tag() (
+	if ! git describe --abbrev=0 --match="$version" --tags; then
+		git tag -u "$gpg_sign_key_id" -s "$tag" -m "version $version"
+		echo "git tag $tag created"
+	else
+		fatal "git tag $tag already exists"
+	fi
+)
+
+git_worktree_is_clean() (
+	if git diff-files --quiet; then
+		return 0
+	fi
+
+	[ -z "$(git ls-files --other --directory --exclude-standard)" ]
+)
+
+usage() {
+	echo "usage: $(basename "$0") VERSION"
+}
+
+## main
+
+if [ $# -ne 1 ]; then
+	err "missing commandline argument"
+	echo
+	usage >&2
+	exit 1
+fi
+
+if [[ "$1" = "-h" || "$1" = "--help" ]]; then
+	usage
+	exit 0
+fi
+
+if ! command -v goreleaser &> /dev/null; then
+	fatal "goreleaser command not found"
+fi
+
+if [[ ! -v GITHUB_TOKEN || -z "$GITHUB_TOKEN" ]]; then
+	fatal "GITHUB_TOKEN environment variable is not set"
+fi
+
+version="$1"
+tag="v$version"
+
+if ! git_worktree_is_clean; then
+	fatal "git work tree is dirty, remove or commit changes, see 'git status' output"
+fi
+
+if git_tag_exists; then
+	fatal "git tag already exists"
+fi
+
+set_unreleased_date
+git commit -m "changelog: release $version" "$changelog_file"
+create_git_tag
+
+GPG_RELEASE_SIGN_KEY_ID="$gpg_sign_key_id" goreleaser release --rm-dist
+git push --tags
+
+echo "Github draft release created, please finalize and publish it on the webpage"
+
+add_new_release_line
+echo "Entry in $changelog_file created for next release, change not committed"


### PR DESCRIPTION
```
        readme: restructure missing features section

-------------------------------------------------------------------------------
        readme: describe release procedure

-------------------------------------------------------------------------------
        scripts: add a goreleaser config + script to create releases

        This commit introduces a goreleaser config, based on the config from the
        terraform-provider-scaffold repository and shell script to create releases.

        The shell script finalizes the CHANGELOG.md file, creates a gpg-signed git tag
        and runs goreleaser.
        Goreleaser creates release binaries, a signed checksum file and creates a draft
        release on github with the release binaries attached.

-------------------------------------------------------------------------------
        gitignore: add dist directory

        goreleaser creates release bins in dist/

```