### PR TITLE
use dev_overrides for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ website/vendor
 terraform-provider-bunny
 
 dist/
+bunny-dev.tftrc

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@ VERSION := dev
 
 OS_ARCH :=$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 BIN := terraform-provider-bunny
-INSTALLDIR := "$(HOME)/.terraform.d/plugins/registry.terraform.io/simplesurance/bunny/$(VERSION)/$(OS_ARCH)"
+INSTALLDIR := "$(HOME)/.terraform.d/plugins/local/simplesurance/bunny/"
 
 LDFLAGS := "-X github.com/simplesurance/terraform-provider-bunny/internal/provider.Version=$(VERSION) -X github.com/simplesurance/terraform-provider-bunny/internal/provider.Commit=$(COMMIT)"
 BUILDFLAGS := -trimpath -ldflags=$(LDFLAGS)
 
+TFTRC_FILENAME := bunny-dev.tftrc
+
 SWEEPERS := pullzones
+
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 default: build
 
@@ -24,9 +28,15 @@ check:
 
 .PHONY: install
 install:
+	$(info * installing provider to $(INSTALLDIR)/$(BIN))
 	GOBIN=$(INSTALLDIR) go install $(BUILDFLAGS)
-	@echo
-	@echo Provider installed to $(INSTALLDIR)/$(BIN)
+
+.PHONY: gen-dev-tftrc
+gen-dev-tftrc:
+	$(info * generating $(TFTRC_FILENAME))
+	@scripts/gen-dev-tftrc.sh "$(INSTALLDIR)" > $(TFTRC_FILENAME)
+	$(info run 'export TF_CLI_CONFIG_FILE=$(REPO_ROOT)/$(TFTRC_FILENAME)' to use it)
+
 
 # Run acceptance tests
 .PHONY: testacc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMMIT := $(shell git describe --tags --always --dirty)
-VERSION := 0.0.1
+VERSION := dev
 
 OS_ARCH :=$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 BIN := terraform-provider-bunny

--- a/README.md
+++ b/README.md
@@ -10,14 +10,31 @@ It currently only supports to manage Pull Zones.
 
 ### Using the Local Provider with Terraform
 
+1. Build and install the provider binary via:
+
+    ```sh
+    make install
+    ```
+
+2. Use the [Development Overrides for Provider
+Developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers)
+feature to enforce using the local `terraform-provider-bunny` binary. \
 Run:
 
-```sh
-make install
-```
+    ```sh
+    make gen-dev-tftrc
+    ```
 
-to compile and install the provider binary into your local
-`$HOME/.terraform.d/plugins/` directory.
+    to generate a terraform config with `dev_overrides` statement, referencing the
+    directory `make install` installed the binary to.
+
+3. Instruct Terraform to use the new config file instead of the default
+one by setting the `TF_CLI_CONFIG_FILE` to the path of the generated
+`bunny-dev.tftrc` file. For example:
+
+    ```sh
+    export TF_CLI_CONFIG_FILE="/home/fho/tf-provider-bunny-dev.tftrc"
+    ```
 
 ### Running Integration Tests
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Bunny.Net Terraform Provider
+
 [![terraformregistry](https://img.shields.io/badge/terraform-registry-blueviolet)](https://registry.terraform.io/providers/simplesurance/bunny)
 
 This repository provides a [Terraform](https://terraform.io) provider for the
@@ -10,6 +11,7 @@ It currently only supports to manage Pull Zones.
 ### Using the Local Provider with Terraform
 
 Run:
+
 ```sh
 make install
 ```
@@ -66,8 +68,8 @@ make docs
 
 3. Publish the draft release on github.
 
-
 ## Known Issues
+
 - When destroying a non-existing pull-zone, the operation fails. It should
   succeed and log a warning instead.
 - testcases are not validating computed field values
@@ -82,9 +84,9 @@ make docs
   - `cache_error_response`
   - `enable_query_string_ordering`
 - Pull Zone fields with missing write support:
-    - `blocked_referrers`
-    - `access_control_origin_header_extensions`
-    - all `enable_geo_zone_*` fields
+  - `blocked_referrers`
+  - `access_control_origin_header_extensions`
+  - all `enable_geo_zone_*` fields
 
 ## Status
 

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -2,6 +2,6 @@ package provider
 
 // Version and Commit can be set during compilation.
 var (
-	Version string
-	Commit  string
+	Version = "version-unset"
+	Commit  = "commit-unset"
 )

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Printf("terraform provider bunny %s (%s)\n", provider.Version, provider.Commit)
+		fmt.Printf("terraform provider bunny, version %s (%s)\n", provider.Version, provider.Commit)
 		os.Exit(0)
 	}
 

--- a/scripts/gen-dev-tftrc.sh
+++ b/scripts/gen-dev-tftrc.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	echo "$(basename "$0") PROVIDER-DIR"
+	echo
+	echo "create a terraform config to use a local provider bin"
+}
+
+
+if [ $# -ne 1 ]; then
+	echo "ERR: missing argument " >&2
+	usage
+	exit 1
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+provider_dir="$(realpath -m "$1")"
+
+cfg='provider_installation {
+  dev_overrides  {
+    "simplesurance/bunny" = "%s"
+  }
+  direct {}
+}'
+
+printf "$cfg" "$provider_dir"


### PR DESCRIPTION
```
 readme: describe how to use terraform's dev_overrides feature

        Document how to use a local compiled terraform-provider-bunny binary via "make
        install gen-dev-tftrc".

        This work more reliable then the previous way. It does not care about eventual
        version constraints and always use the local binary.

-------------------------------------------------------------------------------
        gitignore: add bunny-dev.tftrc

-------------------------------------------------------------------------------
        makefile: add a gen-dev-tftrc target

        Add a target called gen-dev-tftrc to the Makefile.
        When invoked it calls a bash-script which generates a terraform config file with
        a dev_overrides statement that references the INSTALLDIR used in make install.

        Via "make install gen-dev-tftrc", a local provider binary can now be installed
        and a config be generated that can used to use the local binary with terraform.

-------------------------------------------------------------------------------
        version: make the -version output more clear

-------------------------------------------------------------------------------
        makefile: set version to dev

        When building releases the version is set via goreleaser.

        When compiling the binary via the makefile set the version to the string "dev".
        The version of local build binaries is not relevant, it often contains local
        changes and therefore is not the same then a release binary with the same
        version.

-------------------------------------------------------------------------------
        version: set default values for the version and commit variables

        If the binary was build without specifying the linker flags to set the variable,
        an empty string was printed as version and commit.
        This can be confusing. Set the variables that contain the version and commit of
        the binary to values that makes it clear that they are unset.

-------------------------------------------------------------------------------
        readme: fix minor markdown formatting issues

        The rendered view of the document does not change.


```