### PR TITLE
edgerules: support setting enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ make docs
   - `blocked_referrers`
   - `access_control_origin_header_extensions`
   - all `enable_geo_zone_*` fields
-- Edge Rule fields with missing write support:
-  - `enabled`
 
 ## Status
 

--- a/docs/resources/bunny_edgerule.md
+++ b/docs/resources/bunny_edgerule.md
@@ -26,6 +26,7 @@ Valid values: block_request, disable_optimizer, disable_token_auth, enable_token
 
 - **action_parameter_1** (String) The Action parameter 1. The value depends on other parameters of the edge rule.
 - **action_parameter_2** (String) The Action parameter 2. The value depends on other parameters of the edge rule.
+- **enabled** (Boolean) Determines if the edge rule is currently enabled or not.
 - **id** (String) The ID of this resource.
 - **trigger_matching_type** (String) The trigger matching type.
 Valid values: all, any, none
@@ -33,7 +34,6 @@ Valid values: all, any, none
 ### Read-Only
 
 - **description** (String) The description of the Edge Rule. This field is used internally by Terraform bunny-provider.
-- **enabled** (Boolean) Determines if the edge rule is currently enabled or not.
 
 <a id="nestedblock--trigger"></a>
 ### Nested Schema for `trigger`

--- a/internal/provider/resource_edgerule.go
+++ b/internal/provider/resource_edgerule.go
@@ -114,7 +114,8 @@ func resourceEdgeRule() *schema.Resource {
 			keyEdgeRuleEnabled: {
 				Type:        schema.TypeBool,
 				Description: "Determines if the edge rule is currently enabled or not.",
-				Computed:    true,
+				Optional:    true,
+				Default:     true,
 			},
 		},
 	}
@@ -274,6 +275,7 @@ func resourceDataToAddOrUpdateEdgeRuleOptions(d *schema.ResourceData) (*bunny.Ad
 
 	return &bunny.AddOrUpdateEdgeRuleOptions{
 		GUID:                guid,
+		Enabled:             getBoolPtr(d, keyEnabled),
 		ActionType:          &actionType,
 		ActionParameter1:    getStrPtr(d, keyActionParameter1),
 		ActionParameter2:    getStrPtr(d, keyActionParameter2),

--- a/internal/provider/resource_edgerule_test.go
+++ b/internal/provider/resource_edgerule_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -50,6 +51,9 @@ func checkEdgeRulesState(t *testing.T, wanted *edgeRulesWanted) resource.TestChe
 			)
 		}
 
+		sortEdgeRules(t, wanted.EdgeRules)
+		sortEdgeRules(t, pz.EdgeRules)
+
 		for i := range pz.EdgeRules {
 			diff := edgeRuleDiff(t, wanted.EdgeRules[i], pz.EdgeRules[i])
 			if len(diff) != 0 {
@@ -59,6 +63,24 @@ func checkEdgeRulesState(t *testing.T, wanted *edgeRulesWanted) resource.TestChe
 
 		return nil
 	}
+}
+
+func sortEdgeRules(t *testing.T, rules []*bunny.EdgeRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		a := rules[i]
+		b := rules[j]
+
+		if a.ActionType != nil && b.ActionType != nil && ptr.GetInt(a.ActionType) != ptr.GetInt(b.ActionType) {
+			return ptr.GetInt(a.ActionType) < ptr.GetInt(b.ActionType)
+		}
+
+		if a.Description != nil && b.Description != nil && ptr.GetString(a.Description) != ptr.GetString(b.Description) {
+			return ptr.GetString(a.Description) < ptr.GetString(b.Description)
+		}
+
+		t.Logf("WARN: edge rules slice elements not sorted, found no comparable attributes were equal")
+		return false
+	})
 }
 
 var edgeRuleDiffIgnoredFields = map[string]struct{}{


### PR DESCRIPTION
This PR makes the enabled field of Edge-Rules writable.
The Bunny API offers a "Set Edge Rule Enabled" endpoint to specifically
enable/disable edge rules.
It was previously not clear if that endpoint must be used to enable/disable edge
rules.
It turned out that the enabled field can also be set, like all other Edge Rules
field, via the "Update Pull Zone" API endpoint. This made it simple to make the
field writable.
