### PR TITLE
hostname: support load_free_certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make docs
 
 - `terraform import` support
 - unsupported Pull Zone features:
-  - Certificates
+  - Add/Remove custom certificates
   - `cache_error_response`
   - `enable_query_string_ordering`
 - Pull Zone fields with missing write support:

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ make docs
 
 1. Ensure the entry for the version in CHANGELOG.md is uptodate. \
    (Keep the `(Unreleased)` marker.)
-2. Run:  
+2. Run:
 
     ```sh
     scripts/create-release.sh VERSION
-    ``` 
+    ```
 
     To finalize the CHANGELOG.md file, create a signed git tag, build the
     release binaries create a GitHub draft release with the binaries.

--- a/docs/resources/bunny_hostname.md
+++ b/docs/resources/bunny_hostname.md
@@ -23,6 +23,7 @@ description: |-
 ### Optional
 
 - **id** (String) The ID of this resource.
+- **load_free_certificate** (Boolean) Determines if a free SSL certificate should be generated and loaded for the hostname
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0
-	github.com/simplesurance/bunny-go v0.0.0-20211112111434-1bc8f1c9ba18
+	github.com/simplesurance/bunny-go v0.0.0-20211112162547-e3a5bfd91cc5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/simplesurance/bunny-go v0.0.0-20211112111434-1bc8f1c9ba18 h1:g/jlmExWM2sVhjVN8fOQWpyUYR4L0yGQ3q8fD0xhS6g=
-github.com/simplesurance/bunny-go v0.0.0-20211112111434-1bc8f1c9ba18/go.mod h1:KU8W9TK70MvqGIrdCS8OfzAo0SaLXqUl0E1N8ZYpwhY=
+github.com/simplesurance/bunny-go v0.0.0-20211112162547-e3a5bfd91cc5 h1:QwUZ0mKm3+/OB9Fsr9W4G6F7C5UiM0sSEz5n2/XLiY0=
+github.com/simplesurance/bunny-go v0.0.0-20211112162547-e3a5bfd91cc5/go.mod h1:KU8W9TK70MvqGIrdCS8OfzAo0SaLXqUl0E1N8ZYpwhY=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/provider/log.go
+++ b/internal/provider/log.go
@@ -11,6 +11,10 @@ var logger = providerLogger{
 	logger: log.Default(),
 }
 
+func (l *providerLogger) Infof(format string, v ...interface{}) {
+	l.logger.Printf("[INFO] "+format, v...)
+}
+
 func (l *providerLogger) Debugf(format string, v ...interface{}) {
 	l.logger.Printf("[DEBUG] "+format, v...)
 }

--- a/internal/provider/resource_hostname.go
+++ b/internal/provider/resource_hostname.go
@@ -119,7 +119,7 @@ func loadFreeCertRetry(ctx context.Context, clt *bunny.Client, timeout time.Dura
 					if strings.Contains(strings.ToLower(apiErr.Message), "is not pointing to our servers") {
 						logger.Infof("cname dns record missing for hostname %q", hostname)
 
-						return nil, stateWaitingForDNSRecord, nil
+						return "", stateWaitingForDNSRecord, nil
 					}
 
 					return nil, "", err

--- a/internal/provider/resource_hostname.go
+++ b/internal/provider/resource_hostname.go
@@ -5,18 +5,26 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	bunny "github.com/simplesurance/bunny-go"
 )
 
 const (
-	keyHostnamePullZoneID       = "pull_zone_id"
-	keyHostnameHostname         = "hostname" // yes, that variable name is intentional :-)
-	keyHostnameForceSSL         = "force_ssl"
-	keyHostnameIsSystemHostname = "is_system_hostname"
-	keyHostnameHasCertificate   = "has_certificate"
+	keyHostnamePullZoneID          = "pull_zone_id"
+	keyHostnameHostname            = "hostname" // yes, that variable name is intentional :-)
+	keyHostnameForceSSL            = "force_ssl"
+	keyHostnameIsSystemHostname    = "is_system_hostname"
+	keyHostnameHasCertificate      = "has_certificate"
+	keyHostnameLoadFreeCertificate = "load_free_certificate"
+)
+
+const (
+	loadFreeCertMinDelay = 5 * time.Second
 )
 
 func resourceHostname() *schema.Resource {
@@ -53,6 +61,13 @@ func resourceHostname() *schema.Resource {
 				Description: "Determines if the hostname has an SSL certificate configured.",
 				Computed:    true,
 			},
+			keyHostnameLoadFreeCertificate: {
+				Type:        schema.TypeBool,
+				Description: "Determines if a free SSL certificate should be generated and loaded for the hostname",
+				ForceNew:    true,
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -75,7 +90,54 @@ func resourceHostnameCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(hostnameID)
 
+	useFreeSSLCert := d.Get(keyHostnameLoadFreeCertificate).(bool)
+	if !useFreeSSLCert {
+		return nil
+	}
+
+	if err := loadFreeCertRetry(ctx, clt, d.Timeout(schema.TimeoutCreate), *hostnameOpt.Hostname); err != nil {
+		return diagsErrFromErr("creating hostname succeeded, loading free ssl certificate failed", err)
+	}
+
 	return nil
+}
+
+func loadFreeCertRetry(ctx context.Context, clt *bunny.Client, timeout time.Duration, hostname string) error {
+	const (
+		loadFreeCertStateWaitingForDNSRecord = "waiting_for_dns_record"
+		loadFreeCertDone                     = "certificate_loaded"
+	)
+
+	stateConf := resource.StateChangeConf{
+		Pending:    []string{loadFreeCertStateWaitingForDNSRecord},
+		Target:     []string{loadFreeCertDone},
+		Timeout:    timeout,
+		MinTimeout: loadFreeCertMinDelay,
+		Refresh: func() (interface{}, string, error) {
+			err := clt.PullZone.LoadFreeCertificate(ctx, hostname)
+			if err != nil {
+				if apiErr, ok := err.(*bunny.APIError); ok {
+					if strings.Contains(strings.ToLower(apiErr.Message), "is not pointing to our servers") {
+						logger.Infof("cname dns record missing for hostname %q", hostname)
+
+						return nil, loadFreeCertStateWaitingForDNSRecord, nil
+					}
+
+					return nil, "", err
+				}
+
+			}
+
+			// StateChangeConf seems to require that a non-nil
+			// result is returned to consider the state change as successful.
+			// Return an "" instead of nil as result.
+			return "", loadFreeCertDone, nil
+		},
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+
 }
 
 func getHostnameID(ctx context.Context, clt *bunny.Client, pullZoneID int64, hostname string) (string, error) {

--- a/vendor/github.com/simplesurance/bunny-go/pullzone_load_free_certificate.go
+++ b/vendor/github.com/simplesurance/bunny-go/pullzone_load_free_certificate.go
@@ -1,0 +1,21 @@
+package bunny
+
+import "context"
+
+type loadFreeCertificateQueryParams struct {
+	Hostname string `url:"hostname,omitempty"`
+}
+
+// LoadFreeCertificate represents the Load Free Certificate API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_loadfreecertificate
+func (s *PullZoneService) LoadFreeCertificate(ctx context.Context, hostname string) error {
+	params := loadFreeCertificateQueryParams{Hostname: hostname}
+
+	req, err := s.client.newGetRequest("/pullzone/loadFreeCertificate", &params)
+	if err != nil {
+		return err
+	}
+
+	return s.client.sendRequest(ctx, req, nil)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,7 +279,7 @@ github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 ## explicit; go 1.13
 github.com/russross/blackfriday
-# github.com/simplesurance/bunny-go v0.0.0-20211112111434-1bc8f1c9ba18
+# github.com/simplesurance/bunny-go v0.0.0-20211112162547-e3a5bfd91cc5
 ## explicit; go 1.17
 github.com/simplesurance/bunny-go
 # github.com/ulikunitz/xz v0.5.8


### PR DESCRIPTION
hostname: support load_free_certificate

Add a new boolean load_free_certificate field.
If it is set to true, the provider calls the LoadFreeCertificate bunny API
endpoint to generate and load a free cert for the hostname.

Generating the free certificate requires that hostname has a CNAME record
pointing to a bunny.net domain. Because it can take some time until dns changes
are distrubted, loading the free cert is retried, when an error message is
returned that indicates the dns record is missing.
It uses Terraforms default retry timeout.

The bunny api does not provide any interface to get the status of
LoadFreeCertificate or to disable the flag after enabling it once.
Therefore the hostname resource is recreated when it's value changes.

Closes #8 
