### PR TITLE
edgerule: serialize edgerule creations/updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ IMPROVEMENTS:
 * errors: added additional context to error messages of pullzones and edgerules
 * resource/pullzone: new attribute: `cache_error_responses`
 
+BUG FIXES:
+
+* resource/edgerule: the chance that create/update edgerule operations are lost
+                     because of concurrency is minimized. The issue is not fixed
+                     entirely
+                     ([#20](https://github.com/simplesurance/terraform-provider-bunny/issues/20)).
+
 ## 0.2.0 (November 12, 2021)
 
 FEATURES:


### PR DESCRIPTION
As confirmed by the bunny.net support, the "Add/Update Edge Rule" API endpoint
is currently not concurrency safe.
If multiple create/update edge rule operations are done in parallel, it might
happen that parallel changes get lost.

Terraform does operations by default in parallel.
To minimize the chance of edge rule concurrency issues, create/update operations
on edge rule are serialized.
With this fix, the issue could not reproduced anymore via the
TestAccEdgeRule_full testcase. Before this happend in ~25% of the runs.

This is a hotfix.
This workaround does not prevent entirely that edgerule concurrency issues occur.
The delay between create/update operations enforced by the serialization in the
provider might not be sufficient, also it does not protect from parallel changes
via other means than the Terraform provider to occur.

A better fix would be to resend edgerule create/update operations if the change
was not applied. This can be done in a followup.

When concurrency issues happened during edge rule creation, the provider failed
with an error like:
        Error: edge rule (description: "terraform-provider-bunny id:
        23c6b3bc-8b04-4138-ae3a-55f2b5378999") created successfully, looking up
        its guid failed