### PR TITLE
refactor: consistent function names, use structure helpers

### DIFF
--- a/internal/provider/pullzone_safehop.go
+++ b/internal/provider/pullzone_safehop.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	ptr "github.com/AlekSi/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -90,18 +89,17 @@ func safeHopToResource(pz *bunny.PullZone, d *schema.ResourceData) error {
 }
 
 func safehopPullZoneUpdateOptionsFromResource(res *bunny.PullZoneUpdateOptions, d *schema.ResourceData) {
-	safeHopList := d.Get(keySafeHop).([]interface{})
-	if len(safeHopList) == 0 {
+	m := structureFromResource(d, keySafeHop)
+	if len(m) == 0 {
 		return
 	}
-	m := safeHopList[0].(map[string]interface{})
 
-	res.EnableSafeHop = ptr.ToBool(m[keySafeHopEnable].(bool))
-	res.OriginConnectTimeout = ptr.ToInt32(int32(m[keySafeHopOriginConnectTimeout].(int)))
-	res.OriginResponseTimeout = ptr.ToInt32(int32(m[keySafeHopOriginResponseTimeout].(int)))
-	res.OriginRetries = ptr.ToInt32(int32(m[keySafeHopOriginRetries].(int)))
-	res.OriginRetry5xxResponses = ptr.ToBool(m[keySafeHopOriginRetry5xxResponses].(bool))
-	res.OriginRetryConnectionTimeout = ptr.ToBool(m[keySafeHopOriginRetryConnectionTimeout].(bool))
-	res.OriginRetryDelay = ptr.ToInt32(int32(m[keySafeHopOriginRetryDelay].(int)))
-	res.OriginRetryResponseTimeout = ptr.ToBool(m[keySafeHopOriginRetryResponseTimeout].(bool))
+	res.EnableSafeHop = m.getBoolPtr(keySafeHopEnable)
+	res.OriginConnectTimeout = m.getInt32Ptr(keySafeHopOriginConnectTimeout)
+	res.OriginResponseTimeout = m.getInt32Ptr(keySafeHopOriginResponseTimeout)
+	res.OriginRetries = m.getInt32Ptr(keySafeHopOriginRetries)
+	res.OriginRetry5xxResponses = m.getBoolPtr(keySafeHopOriginRetry5xxResponses)
+	res.OriginRetryConnectionTimeout = m.getBoolPtr(keySafeHopOriginRetryConnectionTimeout)
+	res.OriginRetryDelay = m.getInt32Ptr(keySafeHopOriginRetryDelay)
+	res.OriginRetryResponseTimeout = m.getBoolPtr(keySafeHopOriginRetryResponseTimeout)
 }

--- a/internal/provider/pullzone_safehop.go
+++ b/internal/provider/pullzone_safehop.go
@@ -88,7 +88,7 @@ func safeHopToResource(pz *bunny.PullZone, d *schema.ResourceData) error {
 	return d.Set(keySafeHop, []map[string]interface{}{safeHopSettings})
 }
 
-func safehopPullZoneUpdateOptionsFromResource(res *bunny.PullZoneUpdateOptions, d *schema.ResourceData) {
+func safehopFromResource(res *bunny.PullZoneUpdateOptions, d *schema.ResourceData) {
 	m := structureFromResource(d, keySafeHop)
 	if len(m) == 0 {
 		return

--- a/internal/provider/resource_edgerule.go
+++ b/internal/provider/resource_edgerule.go
@@ -165,7 +165,7 @@ func resourceEdgeRuleCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	opts, err := resourceDataToAddOrUpdateEdgeRuleOptions(d)
+	opts, err := edgeRuleFromResource(d)
 	if err != nil {
 		return diagsErrFromErr("setting description failed", err)
 	}
@@ -193,7 +193,7 @@ func resourceEdgeRuleCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceEdgeRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clt := meta.(*bunny.Client)
 
-	opts, err := resourceDataToAddOrUpdateEdgeRuleOptions(d)
+	opts, err := edgeRuleFromResource(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -218,7 +218,7 @@ func edgeRuleTriggerTypeToInt(triggerType string) (int, error) {
 	return -1, fmt.Errorf("unsupported trigger type type: %q", triggerType)
 }
 
-func resourceDataToEdgeRuleTriggers(d *schema.ResourceData) ([]*bunny.EdgeRuleTrigger, error) {
+func edgeRuleTriggersFromResource(d *schema.ResourceData) ([]*bunny.EdgeRuleTrigger, error) {
 	triggerSet := d.Get(keyEdgeRuleTriggers).(*schema.Set)
 	if triggerSet.Len() == 0 {
 		return nil, nil
@@ -259,7 +259,7 @@ func resourceDataToEdgeRuleTriggers(d *schema.ResourceData) ([]*bunny.EdgeRuleTr
 	return res, nil
 }
 
-func resourceDataToAddOrUpdateEdgeRuleOptions(d *schema.ResourceData) (*bunny.AddOrUpdateEdgeRuleOptions, error) {
+func edgeRuleFromResource(d *schema.ResourceData) (*bunny.AddOrUpdateEdgeRuleOptions, error) {
 	var guid *string
 	if id := d.Id(); id != "" {
 		guid = &id
@@ -281,7 +281,7 @@ func resourceDataToAddOrUpdateEdgeRuleOptions(d *schema.ResourceData) (*bunny.Ad
 		return nil, err
 	}
 
-	triggers, err := resourceDataToEdgeRuleTriggers(d)
+	triggers, err := edgeRuleTriggersFromResource(d)
 	if err != nil {
 		return nil, fmt.Errorf("converting edge rule triggers failed: %w", err)
 	}
@@ -333,7 +333,7 @@ func resourceEdgeRuleRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	for _, er := range pz.EdgeRules {
 		if er.GUID != nil && *er.GUID == edgeRuleGUID {
-			if err := edgeRuleToResourceData(er, d); err != nil {
+			if err := edgeRuleToResource(er, d); err != nil {
 				return diagsErrFromErr("converting edge rule api type to terraform ResourceData failed", err)
 			}
 
@@ -348,7 +348,7 @@ func resourceEdgeRuleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}}
 }
 
-func edgeRuleToResourceData(edgeRule *bunny.EdgeRule, d *schema.ResourceData) error {
+func edgeRuleToResource(edgeRule *bunny.EdgeRule, d *schema.ResourceData) error {
 	if edgeRule.GUID == nil || *edgeRule.GUID == "" {
 		return errors.New("guid is empty")
 	}
@@ -372,7 +372,7 @@ func edgeRuleToResourceData(edgeRule *bunny.EdgeRule, d *schema.ResourceData) er
 		return err
 	}
 
-	err = edgeRuleTriggerToResourceData(edgeRule.Triggers, d)
+	err = edgeRuleTriggerToResource(edgeRule.Triggers, d)
 	if err != nil {
 		return fmt.Errorf("converting triggers to resource data failed: %w", err)
 	}
@@ -397,7 +397,7 @@ func edgeRuleToResourceData(edgeRule *bunny.EdgeRule, d *schema.ResourceData) er
 	return nil
 }
 
-func edgeRuleTriggerToResourceData(triggers []*bunny.EdgeRuleTrigger, d *schema.ResourceData) error {
+func edgeRuleTriggerToResource(triggers []*bunny.EdgeRuleTrigger, d *schema.ResourceData) error {
 	res := make([]map[string]interface{}, 0, len(triggers))
 
 	for _, trigger := range triggers {

--- a/internal/provider/resource_hostname.go
+++ b/internal/provider/resource_hostname.go
@@ -171,12 +171,12 @@ func resourceHostnameDelete(ctx context.Context, d *schema.ResourceData, meta in
 	clt := meta.(*bunny.Client)
 
 	pullZoneID := int64(d.Get(keyHostnamePullZoneID).(int))
-	hostnameOpt := resourceDataToRemoveCustomHostnameOpt(d)
+	hostnameOpt := hostnameFromResource(d)
 
 	return diag.FromErr(clt.PullZone.RemoveCustomHostname(ctx, pullZoneID, hostnameOpt))
 }
 
-func resourceDataToRemoveCustomHostnameOpt(d *schema.ResourceData) *bunny.RemoveCustomHostnameOptions {
+func hostnameFromResource(d *schema.ResourceData) *bunny.RemoveCustomHostnameOptions {
 	hostname := d.Get(keyHostnameHostname).(string)
 	return &bunny.RemoveCustomHostnameOptions{
 		Hostname: &hostname,
@@ -207,7 +207,7 @@ func resourceHostnameRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	for _, hostname := range pz.Hostnames {
 		if hostname.ID != nil && *hostname.ID == hostnameID {
-			if err := hostnameToResourceData(hostname, d); err != nil {
+			if err := hostnameToResource(hostname, d); err != nil {
 				return diagsErrFromErr("converting api hostname to resource data failed", err)
 			}
 
@@ -222,7 +222,7 @@ func resourceHostnameRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}}
 }
 
-func hostnameToResourceData(hostname *bunny.Hostname, d *schema.ResourceData) error {
+func hostnameToResource(hostname *bunny.Hostname, d *schema.ResourceData) error {
 	if hostname.ID == nil {
 		return errors.New("id is empty")
 	}

--- a/internal/provider/resource_pullzone.go
+++ b/internal/provider/resource_pullzone.go
@@ -583,7 +583,7 @@ func resourcePullZoneCreate(ctx context.Context, d *schema.ResourceData, meta in
 			Summary:  "setting pull zone attributes via update failed",
 		})
 
-		if err := pullZoneToResourceData(pz, d); err != nil {
+		if err := pullZoneToResource(pz, d); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "converting api-type to resource data failed: " + err.Error(),
@@ -600,7 +600,7 @@ func resourcePullZoneCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourcePullZoneUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clt := meta.(*bunny.Client)
 
-	pullZone, err := resourceDataToPullZoneUpdate(d)
+	pullZone, err := pullZoneFromResource(d)
 	if err != nil {
 		return diagsErrFromErr("converting resource to API type failed", err)
 	}
@@ -615,7 +615,7 @@ func resourcePullZoneUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return diagsErrFromErr("updating pull zone via API failed", err)
 	}
 
-	if err := pullZoneToResourceData(updatedPullZone, d); err != nil {
+	if err := pullZoneToResource(updatedPullZone, d); err != nil {
 		return diagsErrFromErr("converting api type to resource data after successful update failed: %w", err)
 	}
 
@@ -642,7 +642,7 @@ func resourcePullZoneRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diagsErrFromErr("could not retrieve pull zone", err)
 	}
 
-	if err := pullZoneToResourceData(pz, d); err != nil {
+	if err := pullZoneToResource(pz, d); err != nil {
 		return diagsErrFromErr("converting api type to resource data after successful read failed: %w", err)
 	}
 
@@ -667,8 +667,8 @@ func resourcePullZoneDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-// pullZoneToResourceData sets fields in d to the values in pz.
-func pullZoneToResourceData(pz *bunny.PullZone, d *schema.ResourceData) error {
+// pullZoneToResource sets fields in d to the values in pz.
+func pullZoneToResource(pz *bunny.PullZone, d *schema.ResourceData) error {
 	if pz.ID != nil {
 		d.SetId(strconv.FormatInt(*pz.ID, 10))
 	}
@@ -905,9 +905,9 @@ func pullZoneToResourceData(pz *bunny.PullZone, d *schema.ResourceData) error {
 	return nil
 }
 
-// resourceDataToPullZoneUpdate returns a PullZoneUpdateOptions API type that
+// pullZoneFromResource returns a PullZoneUpdateOptions API type that
 // has fields set to the values in d.
-func resourceDataToPullZoneUpdate(d *schema.ResourceData) (*bunny.PullZoneUpdateOptions, error) {
+func pullZoneFromResource(d *schema.ResourceData) (*bunny.PullZoneUpdateOptions, error) {
 	var res bunny.PullZoneUpdateOptions
 
 	res.AWSSigningEnabled = getBoolPtr(d, keyAWSSigningEnabled)
@@ -971,7 +971,7 @@ func resourceDataToPullZoneUpdate(d *schema.ResourceData) (*bunny.PullZoneUpdate
 	res.ZoneSecurityEnabled = getBoolPtr(d, keyZoneSecurityEnabled)
 	res.ZoneSecurityIncludeHashRemoteIP = getBoolPtr(d, keyZoneSecurityIncludeHashRemoteIP)
 
-	safehopPullZoneUpdateOptionsFromResource(&res, d)
+	safehopFromResource(&res, d)
 	headersFromResource(&res, d)
 	limitsFromResource(&res, d)
 


### PR DESCRIPTION
```
pullzone: use consistent naming schema for from/to resourceData conversion funcs

Rename the function to be consistent with equivalent functions for the headers
and limits blocks

-------------------------------------------------------------------------------
safehop: use structure helpers

```

merge after #35 