### PR TITLE
hostname: support setting the force_ssl attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.5.0 (Unreleased)
 
+IMPROVEMENTS:
+
+* resource/hostname: the `force_ssl` attribute is not a computed field anymore
+                     and can be set
+
 ## 0.4.0 (November 26, 2021)
 
 BREAKING CHANGES:

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ make docs
 - Pull Zone fields with missing write support:
   - `blocked_referrers`
   - all `enable_geo_zone_*` fields
-- Hostname fields with missing write support:
-  - `force_ssl`
 
 ## Status
 

--- a/docs/resources/bunny_hostname.md
+++ b/docs/resources/bunny_hostname.md
@@ -22,12 +22,12 @@ description: |-
 
 ### Optional
 
+- **force_ssl** (Boolean) Determines if the Force SSL feature is enabled.
 - **id** (String) The ID of this resource.
 - **load_free_certificate** (Boolean) Determines if a free SSL certificate should be generated and loaded for the hostname
 
 ### Read-Only
 
-- **force_ssl** (Boolean) Determines if the Force SSL feature is enabled.
 - **has_certificate** (Boolean) Determines if the hostname has an SSL certificate configured.
 - **is_system_hostname** (Boolean) Determines if this is a system hostname controlled by bunny.net.
 

--- a/internal/provider/resource_hostname.go
+++ b/internal/provider/resource_hostname.go
@@ -206,13 +206,21 @@ func resourceHostnameRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	for _, hostname := range pz.Hostnames {
-		if hostname.ID != nil && *hostname.ID == hostnameID {
-			if err := hostnameToResource(hostname, d); err != nil {
-				return diagsErrFromErr("converting api hostname to resource data failed", err)
-			}
-
-			return nil
+		if hostname.ID == nil {
+			logger.Warnf("got hostname with nil ID for pull zone: %d", pullZoneID)
+			continue
 		}
+
+		if *hostname.ID == *hostname.ID {
+			logger.Warnf("got hostname with empty ID for pull zone: %d", pullZoneID)
+			continue
+		}
+
+		if err := hostnameToResource(hostname, d); err != nil {
+			return diagsErrFromErr("converting api hostname to resource data failed", err)
+		}
+
+		return nil
 	}
 
 	return diag.Diagnostics{{

--- a/internal/provider/resource_hostname_test.go
+++ b/internal/provider/resource_hostname_test.go
@@ -137,6 +137,7 @@ resource "bunny_pullzone" "pz" {
 resource "bunny_hostname" "h1" {
 	pull_zone_id = bunny_pullzone.pz.id
 	hostname = "google.de"
+	force_ssl = true
 }
 
 resource "bunny_hostname" "h2" {
@@ -162,7 +163,7 @@ resource "bunny_hostname" "h3" {
 						},
 						{
 							Value:            ptr.ToString("google.de"),
-							ForceSSL:         ptr.ToBool(false),
+							ForceSSL:         ptr.ToBool(true),
 							IsSystemHostname: ptr.ToBool(false),
 							HasCertificate:   ptr.ToBool(false),
 						},

--- a/internal/provider/structure.go
+++ b/internal/provider/structure.go
@@ -28,7 +28,7 @@ func structureFromResource(d *schema.ResourceData, key string) structure {
 
 func structureFromElem(e []interface{}) structure {
 	if len(e) == 0 {
-		logger.Debugf("structureFromResource: %q slice is empty")
+		logger.Debugf("structureFromResource: slice is empty")
 		return nil
 	}
 


### PR DESCRIPTION
```
hostname: support setting the force_ssl attribute

The computed option for the force_ssl attribute is disable.  The field can now
be set.

-------------------------------------------------------------------------------
hostname: log warn message when pullzone has hostname with nil id

That the API returns a hostname with a nil ID should not happend.
If it does anyways, log a warning message.

-------------------------------------------------------------------------------
structure: remove unused format specifier in debug message

-------------------------------------------------------------------------------
scripts: fix: commit changelog file change did not work

Changes are not staged and therefore "-" or the path to the files that should be
commited must be passed

-------------------------------------------------------------------------------
```