### PR TITLE
hostname: fix: plan not empty after hostname creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ IMPROVEMENTS:
 * resource/hostname: the `force_ssl` attribute is not a computed field anymore
                      and can be set
 
+BUG FIXES:
+
+* resource/hostname: fix: plan was not empty after hostname creation
+
 ## 0.4.0 (November 26, 2021)
 
 BREAKING CHANGES:

--- a/internal/provider/resource_hostname_test.go
+++ b/internal/provider/resource_hostname_test.go
@@ -182,6 +182,7 @@ resource "bunny_hostname" "h3" {
 					},
 				}),
 			},
+
 			// Change all 3 hostname
 			{
 				Config: tfPz + `
@@ -279,7 +280,6 @@ resource "bunny_hostname" "h1" {
 	pull_zone_id = bunny_pullzone.pz.id
 	hostname = "%s"
 }
-
 `, pzName, defPullZoneHostname(pzName))
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
```
After creating a new hostname a following  "terraform plan" command would show a
non-empty diff.
The values of the computed fields of a hostname were not retrieved and set in
the ResourceData after the creation.

Retrieve full hostname after creation and set the ResourceData to the retrieved
values from the API.
```

I could not figure out way to add a testcase for this. Setting PlanOnly in the test step did not cause an error if the plan was not empty. Suggestions for how to write a test for it are very welcome. :-)

Merge after https://github.com/simplesurance/terraform-provider-bunny/pull/38