### PR TITLE
edgerule: fix: moving edge-rules to another pull-zone fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.6.0 (Unreleased)
 
+BUG FIXES:
+
+* resource/edgerule: changing the `pull_zone_id` of an edgerule resulted in
+                     API errors
+
 IMPROVEMENTS:
 
 * resource/hostname: new block `certificate`, for providing custom SSL

--- a/internal/provider/resource_edgerule.go
+++ b/internal/provider/resource_edgerule.go
@@ -48,6 +48,7 @@ func resourceEdgeRule() *schema.Resource {
 				Type:        schema.TypeInt,
 				Description: "The ID of the Pull Zone to that Edge Rule belongs.",
 				Required:    true,
+				ForceNew:    true,
 			},
 			keyEdgeRuleActionType: {
 				Type: schema.TypeString,

--- a/internal/provider/resource_edgerule_test.go
+++ b/internal/provider/resource_edgerule_test.go
@@ -556,3 +556,53 @@ resource "bunny_edgerule" "er2" {
 		},
 	})
 }
+
+func TestAccEdgeRule_changePullZoneID(t *testing.T) {
+	pzName1 := randPullZoneName()
+	pzName2 := randPullZoneName()
+
+	tfPz := fmt.Sprintf(`
+resource "bunny_pullzone" "pz1" {
+	name = "%s"
+	origin_url ="https://bunny.net"
+}
+
+resource "bunny_pullzone" "pz2" {
+	name = "%s"
+	origin_url ="https://bunny.net"
+} `, pzName1, pzName2)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tfPz + `
+resource "bunny_edgerule" "er1" {
+	pull_zone_id = bunny_pullzone.pz1.id
+	enabled = false
+	action_type = "block_request"
+	trigger_matching_type = "all"
+	trigger {
+		pattern_matching_type = "any"
+		type = "random_chance"
+		pattern_matches = ["30"]
+	}
+}`,
+			},
+			{
+				Config: tfPz + `
+resource "bunny_edgerule" "er1" {
+	pull_zone_id = bunny_pullzone.pz2.id
+	enabled = false
+	action_type = "block_request"
+	trigger_matching_type = "all"
+	trigger {
+		pattern_matching_type = "any"
+		type = "random_chance"
+		pattern_matches = ["30"]
+	}
+}`,
+			},
+		},
+	})
+}


### PR DESCRIPTION
```
edgerule: fix: moving edge-rules to another pull-zone fails

When the pull_zone_id field of an edge rule was changed, e.g. to move an
edge rule to another pull zone, the operation failed with the error:
        updating edge rule failed: http-request to
        https://api.bunny.net/pullzone/XXXXXY/edgerules/addOrUpdate failed: Not
        Found (404)

Following "terraform apply" runs failed with the error:
        "pull zone has no edge rules"

Moving an edge-rule is not supported, it must be recreated for another
pull-zone.
The resource definition lacked to enable the ForceNew behaviour for the
pull_zone_id field, which caused the issue.

-------------------------------------------------------------------------------
edgerule: add testcase that changes the pull_zone_id of an edge rule

Add a testcase that creates 2 pull zones, one of them with an Edgerule.
Afterwards it changes the pull-zone ID of the edgerule.

This reproduces the bug report:
https://github.com/simplesurance/terraform-provider-bunny/issues/42
```

This closes #42.
**Must be merged after** https://github.com/simplesurance/terraform-provider-bunny/pull/44