### PR TITLE
edge rules: support new action and trigger types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ BREAKING CHANGES:
 * resource/edgerule: renamed action type `ignore_quiery_string` to
                      `ignore_query_string`
 
+IMPROVEMENTS:
+
+* resource/edgerule: support action types `set_status_code` and
+                     `bypass_perma_cache`
+
 ## 0.6.0 (Januar 31, 2022)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMPROVEMENTS:
 
 * resource/edgerule: support action types `set_status_code` and
                      `bypass_perma_cache`
+* resource/edgerule: support trigger types `status_code` and
+                     `request_method`
 
 ## 0.6.0 (Januar 31, 2022)
 

--- a/docs/resources/bunny_edgerule.md
+++ b/docs/resources/bunny_edgerule.md
@@ -18,7 +18,7 @@ description: |-
 ### Required
 
 - **action_type** (String) The action type of the Edge Rule.
-Valid values: block_request, disable_optimizer, disable_token_auth, enable_token_auth, force_compression, force_download, force_ssl, ignore_quiery_string, origin_url, override_cache_time, override_cache_time_public, redirect, set_request_header, set_response_header
+Valid values: block_request, bypass_perma_cache, disable_optimizer, disable_token_auth, enable_token_auth, force_compression, force_download, force_ssl, ignore_query_string, origin_url, override_cache_time, override_cache_time_public, redirect, set_request_header, set_response_header, set_status_code
 - **pull_zone_id** (Number) The ID of the Pull Zone to that Edge Rule belongs.
 - **trigger** (Block Set, Min: 1, Max: 5) (see [below for nested schema](#nestedblock--trigger))
 

--- a/docs/resources/bunny_edgerule.md
+++ b/docs/resources/bunny_edgerule.md
@@ -43,7 +43,7 @@ Required:
 - **pattern_matching_type** (String) The type of pattern matching.
 Valid values: all, any, none
 - **type** (String) The type of the Trigger.
-Valid values: country_code, query_string, random_chance, remote_ip, request_header, response_header, url, url_extensions
+Valid values: country_code, query_string, random_chance, remote_ip, request_header, request_method, response_header, status_code, url, url_extensions
 
 Optional:
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/simplesurance/bunny-go v0.0.0-20220104105156-b14fa086f4c9
+	github.com/simplesurance/bunny-go v0.0.0-20220202145800-6eafc6db3801
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/simplesurance/bunny-go v0.0.0-20220104105156-b14fa086f4c9 h1:iifj4swK3ypmyl6BlTldZPMRQyI/OTQG82u01m3vQ9E=
-github.com/simplesurance/bunny-go v0.0.0-20220104105156-b14fa086f4c9/go.mod h1:KU8W9TK70MvqGIrdCS8OfzAo0SaLXqUl0E1N8ZYpwhY=
+github.com/simplesurance/bunny-go v0.0.0-20220202145800-6eafc6db3801 h1:v6SWot2pyXzcYCX2JU5XooR7nX3VEk8xpxPZV3dq2zU=
+github.com/simplesurance/bunny-go v0.0.0-20220202145800-6eafc6db3801/go.mod h1:KU8W9TK70MvqGIrdCS8OfzAo0SaLXqUl0E1N8ZYpwhY=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/provider/edge_rule_action_types.go
+++ b/internal/provider/edge_rule_action_types.go
@@ -19,6 +19,8 @@ var edgeRuleActionTypesStr = map[string]int{
 	"ignore_query_string":        bunny.EdgeRuleActionTypeIgnoreQueryString,
 	"disable_optimizer":          bunny.EdgeRuleActionTypeDisableOptimizer,
 	"force_compression":          bunny.EdgeRuleActionTypeForceCompression,
+	"set_status_code":            bunny.EdgeRuleActionTypeSetStatusCode,
+	"bypass_perma_cache":         bunny.EdgeRuleActionTypeBypassPermaCache,
 }
 
 var edgeRuleActionTypesInt = reverseStrIntMap(edgeRuleActionTypesStr)

--- a/internal/provider/edge_rule_trigger_types.go
+++ b/internal/provider/edge_rule_trigger_types.go
@@ -11,6 +11,8 @@ var edgeRuleTriggerTypesStr = map[string]int{
 	"remote_ip":       bunny.EdgeRuleTriggerTypeRemoteIP,
 	"query_string":    bunny.EdgeRuleTriggerTypeURLQueryString,
 	"random_chance":   bunny.EdgeRuleTriggerTypeRandomChance,
+	"status_code":     bunny.EdgeRuleTriggerTypeStatusCode,
+	"request_method":  bunny.EdgeRuleTriggerTypeRequestMethod,
 }
 
 var edgeRuleTriggerTypesInt = reverseStrIntMap(edgeRuleTriggerTypesStr)

--- a/vendor/github.com/simplesurance/bunny-go/README.md
+++ b/vendor/github.com/simplesurance/bunny-go/README.md
@@ -31,7 +31,7 @@ Endpoints](https://docs.bunny.net/reference/bunnynet-api-overview) are supported
     - [ ] Purge Cache
     - [x] Load Free Certificate
     - [x] Add Custom Certificate
-    - [ ] Remove Certificate
+    - [x] Remove Certificate
     - [x] Add Custom Hostname
     - [x] Remove Custom Hostname
     - [x] Set Force SSL

--- a/vendor/github.com/simplesurance/bunny-go/edgerules.go
+++ b/vendor/github.com/simplesurance/bunny-go/edgerules.go
@@ -1,0 +1,43 @@
+package bunny
+
+// EdgeRuleTrigger represents the values of the Trigger field of an EdgeRule.
+type EdgeRuleTrigger struct {
+	Type                *int     `json:"Type,omitempty"`
+	PatternMatches      []string `json:"PatternMatches,omitempty"`
+	PatternMatchingType *int     `json:"PatternMatchingType,omitempty"`
+	Parameter1          *string  `json:"Parameter1,omitempty"`
+}
+
+// Constants for the ActionType fields of an EdgeRule.
+const (
+	EdgeRuleActionTypeForceSSL int = iota
+	EdgeRuleActionTypeRedirect
+	EdgeRuleActionTypeOriginURL
+	EdgeRuleActionTypeOverrideCacheTime
+	EdgeRuleActionTypeBlockRequest
+	EdgeRuleActionTypeSetResponseHeader
+	EdgeRuleActionTypeSetRequestHeader
+	EdgeRuleActionTypeForceDownload
+	EdgeRuleActionTypeDisableTokenAuthentication
+	EdgeRuleActionTypeEnableTokenAuthentication
+	EdgeRuleActionTypeOverrideCacheTimePublic
+	EdgeRuleActionTypeIgnoreQueryString
+	EdgeRuleActionTypeDisableOptimizer
+	EdgeRuleActionTypeForceCompression
+	EdgeRuleActionTypeSetStatusCode
+	EdgeRuleActionTypeBypassPermaCache
+)
+
+// Constants for the Type field of an EdgeRuleTrigger.
+const (
+	EdgeRuleTriggerTypeURL int = iota
+	EdgeRuleTriggerTypeRequestHeader
+	EdgeRuleTriggerTypeResponseHeader
+	EdgeRuleTriggerTypeURLExtension
+	EdgeRuleTriggerTypeCountryCode
+	EdgeRuleTriggerTypeRemoteIP
+	EdgeRuleTriggerTypeURLQueryString
+	EdgeRuleTriggerTypeRandomChance
+	EdgeRuleTriggerTypeStatusCode
+	EdgeRuleTriggerTypeRequestMethod
+)

--- a/vendor/github.com/simplesurance/bunny-go/pullzone_add_custom_hostname.go
+++ b/vendor/github.com/simplesurance/bunny-go/pullzone_add_custom_hostname.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// AddCustomHostnameOptions  represents the message that is sent to the
+// AddCustomHostnameOptions represents the message that is sent to the
 // Add Custom Hostname API Endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_addhostname

--- a/vendor/github.com/simplesurance/bunny-go/pullzone_get.go
+++ b/vendor/github.com/simplesurance/bunny-go/pullzone_get.go
@@ -19,36 +19,6 @@ const (
 	MatchingTypeNone
 )
 
-// Constants for the ActionType fields of an EdgeRule.
-const (
-	EdgeRuleActionTypeForceSSL int = iota
-	EdgeRuleActionTypeRedirect
-	EdgeRuleActionTypeOriginURL
-	EdgeRuleActionTypeOverrideCacheTime
-	EdgeRuleActionTypeBlockRequest
-	EdgeRuleActionTypeSetResponseHeader
-	EdgeRuleActionTypeSetRequestHeader
-	EdgeRuleActionTypeForceDownload
-	EdgeRuleActionTypeDisableTokenAuthentication
-	EdgeRuleActionTypeEnableTokenAuthentication
-	EdgeRuleActionTypeOverrideCacheTimePublic
-	EdgeRuleActionTypeIgnoreQueryString
-	EdgeRuleActionTypeDisableOptimizer
-	EdgeRuleActionTypeForceCompression
-)
-
-// Constants for the Type field of an EdgeRuleTrigger.
-const (
-	EdgeRuleTriggerTypeURL int = iota
-	EdgeRuleTriggerTypeRequestHeader
-	EdgeRuleTriggerTypeResponseHeader
-	EdgeRuleTriggerTypeURLExtension
-	EdgeRuleTriggerTypeCountryCode
-	EdgeRuleTriggerTypeRemoteIP
-	EdgeRuleTriggerTypeURLQueryString
-	EdgeRuleTriggerTypeRandomChance
-)
-
 // PullZone represents the response of the the List and Get Pull Zone API endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_index2 https://docs.bunny.net/reference/pullzonepublic_index
@@ -187,14 +157,6 @@ type EdgeRule struct {
 	TriggerMatchingType *int               `json:"TriggerMatchingType,omitempty"`
 	Description         *string            `json:"Description,omitempty"`
 	Enabled             *bool              `json:"Enabled,omitempty"`
-}
-
-// EdgeRuleTrigger represents the values of the Trigger field of an EdgeRule.
-type EdgeRuleTrigger struct {
-	Type                *int     `json:"Type,omitempty"`
-	PatternMatches      []string `json:"PatternMatches,omitempty"`
-	PatternMatchingType *int     `json:"PatternMatchingType,omitempty"`
-	Parameter1          *string  `json:"Parameter1,omitempty"`
 }
 
 // Get retrieves the Pull Zone with the given id.

--- a/vendor/github.com/simplesurance/bunny-go/pullzone_remove_certificate.go
+++ b/vendor/github.com/simplesurance/bunny-go/pullzone_remove_certificate.go
@@ -1,0 +1,26 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// RemoveCertificateOptions represents the request parameters for the Remove
+// Certificate API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removecertificate
+type RemoveCertificateOptions struct {
+	Hostname *string `json:"Hostname,omitempty"`
+}
+
+// RemoveCertificate represents the Remove Certificate API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removecertificate
+func (s *PullZoneService) RemoveCertificate(ctx context.Context, pullZoneID int64, options *RemoveCertificateOptions) error {
+	req, err := s.client.newDeleteRequest(fmt.Sprintf("/pullzone/%d/removeCertificate", pullZoneID), options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.sendRequest(ctx, req, nil)
+}

--- a/vendor/github.com/simplesurance/bunny-go/pullzone_remove_custom_hostname.go
+++ b/vendor/github.com/simplesurance/bunny-go/pullzone_remove_custom_hostname.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// RemoveCustomHostnameOptions  represents the message that is sent to the
+// RemoveCustomHostnameOptions represents the message that is sent to the
 // Remove Custom Hostname API Endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removehostname

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,7 +311,7 @@ github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 ## explicit; go 1.13
 github.com/russross/blackfriday
-# github.com/simplesurance/bunny-go v0.0.0-20220104105156-b14fa086f4c9
+# github.com/simplesurance/bunny-go v0.0.0-20220202145800-6eafc6db3801
 ## explicit; go 1.17
 github.com/simplesurance/bunny-go
 # github.com/ulikunitz/xz v0.5.8


### PR DESCRIPTION
```
edgerule: support trigger types status_code and request_method

-------------------------------------------------------------------------------
edgerule: support action type set_status_code and bypass_perma_cache

-------------------------------------------------------------------------------
vendor: update bunny-go
```

The new action and trigger types shown up in the admin-ui but are not documented in the API documentation.
