### PR TITLE
Watermark enabled change default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.7.1 (Unreleased)
 
+BUG FIXES:
+
+* resource/edgerule: after edge rule creation the plan was not empty, change the
+                     default value of `watermark_enabled` to false, this adapts
+                     it to the changed default of the bunny endpoint
+
 IMPROVEMENTS:
 
 * provider: upgrade terraform-plugin-sdk from version 2.10.1 to 2.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
-* provider: upgrade terraform-plugin-sdk from version 2.10.1 to 2.11.0
+* provider: upgrade terraform-plugin-sdk to version 2.17.0
+* provider: upgrade github.com/hashicorp/terraform-plugin-docs to version 0.9.0
 
 ## 0.7.0 (Februar 03, 2022)
 

--- a/internal/provider/pullzone_optimizer.go
+++ b/internal/provider/pullzone_optimizer.go
@@ -117,7 +117,7 @@ var resourcePullZoneOptimizer = &schema.Resource{
 					keyOptimizerWatermarkEnabled: {
 						Type:        schema.TypeBool,
 						Description: "Determines if image watermarking should be enabled.",
-						Default:     true,
+						Default:     false,
 						Optional:    true,
 					},
 					keyOptimizerWatermarkURL: {


### PR DESCRIPTION
```
changelog: adapt vendor-package update entries to current versions

-------------------------------------------------------------------------------
edgerule: change default WatermarkEnabled value to true

The default on the bunny API endpoint.
This caused that a change is detected after an edge-rule was created (plan not
empty).

Adapt the default value in the provider to the one that the endpoint uses.

-------------------------------------------------------------------------------
```