### PR TITLE
fix: TestAccHostname_StateIsValidWhenCertUploadFails testcase fails

### DIFF
--- a/internal/provider/resource_hostname_test.go
+++ b/internal/provider/resource_hostname_test.go
@@ -484,6 +484,8 @@ resource "bunny_hostname" "h1" {
 }
 
 func TestAccHostname_StateIsValidWhenCertUploadFails(t *testing.T) {
+	t.Skip("disabled, because test sends 800kiB of bogus data to bunny api, which is not kind")
+
 	pzName := randPullZoneName()
 	hostname := randHostname()
 
@@ -491,6 +493,8 @@ func TestAccHostname_StateIsValidWhenCertUploadFails(t *testing.T) {
 	// valid certificate.
 	// To cause an API error, we post a big amount of zero bits which
 	// causes a 500 error.
+	// TODO: find a way to generate an error that does not require sending
+	// a lot of bogus data.
 	var bogusCertData [800 * 1024]byte
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_hostname_test.go
+++ b/internal/provider/resource_hostname_test.go
@@ -487,6 +487,12 @@ func TestAccHostname_StateIsValidWhenCertUploadFails(t *testing.T) {
 	pzName := randPullZoneName()
 	hostname := randHostname()
 
+	// The bunny API does not return an error if the posted data is not a
+	// valid certificate.
+	// To cause an API error, we post a big amount of zero bits which
+	// causes a 500 error.
+	var bogusCertData [800 * 1024]byte
+
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		Steps: []resource.TestStep{
@@ -506,11 +512,11 @@ resource "bunny_hostname" "h1" {
 	hostname = %q
 
 	certificate {
-		certificate_data = "1234"
+		certificate_data = "%x"
 		private_key_data = "5678"
 	}
 }
-`, pzName, hostname),
+`, pzName, hostname, bogusCertData),
 				ExpectError: regexp.MustCompile(".*uploading certificate failed.*"),
 			},
 			// the local terraform state should not be broken,


### PR DESCRIPTION
```
tests: disable TestAccHostname_StateIsValidWhenCertUploadFails

Sending 800kiB to the bunny api is causing unnecessary traffic.
Disable the testcase for now. It could still be enabled manually or maybe we
find a better way in the future to generate an error.

-------------------------------------------------------------------------------
tests: fix: AccHostname_StateIsValidWhenCertUploadFails test fails

The TestAccHostname_StateIsValidWhenCertUploadFails started to fail because the
bunny.net API is not returning an error anymore when invalid data is posted as
certificate.

To generate an API error we post 800kiB of zeroes instead, which causes a 500
error.
This is the lowest value that I've tested that generates an error, 700kiB does
not.

-------------------------------------------------------------------------------
```