### PR TITLE
pullzone: storage_zone_id & origin_url mutually exclusive follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+* resource/edgerule: allow specifying only `origin_url` or `storage_zone_id`
 * provider: upgrade terraform-plugin-sdk to version 2.17.0
 * provider: upgrade github.com/hashicorp/terraform-plugin-docs to version 0.9.0
 

--- a/docs/resources/bunny_pullzone.md
+++ b/docs/resources/bunny_pullzone.md
@@ -18,7 +18,6 @@ description: |-
 ### Required
 
 - `name` (String) The name of the Pull Zone.
-- `origin_url` (String) The origin URL of the Pull Zone where the files are fetched from.
 
 ### Optional
 
@@ -66,6 +65,7 @@ If disabled, error responses will be set to no-cache.
 - `logging_storage_zone_id` (Number) Sets the Storage Zone id that should contain the logs from this Pull Zone.
 - `optimizer` (Block List, Max: 1) (see [below for nested schema](#nestedblock--optimizer))
 - `origin_shield_zone_code` (String) Determines the zone code where the origin shield should be set up.
+- `origin_url` (String) The origin URL of the Pull Zone where the files are fetched from.
 - `perma_cache_storage_zone_id` (Number) The ID of the storage zone that should be used as the Perma-Cache.
 - `safehop` (Block List, Max: 1) (see [below for nested schema](#nestedblock--safehop))
 - `storage_zone_id` (Number) The ID of the storage zone that the Pull Zone is linked to.

--- a/internal/provider/resource_pullzone.go
+++ b/internal/provider/resource_pullzone.go
@@ -428,11 +428,10 @@ func resourcePullZone() *schema.Resource {
 				Description: "The name of the Pull Zone.",
 			},
 			keyStorageZoneID: {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Description:  "The ID of the storage zone that the Pull Zone is linked to.",
-				ExactlyOneOf: []string{keyOriginURL},
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the storage zone that the Pull Zone is linked to.",
 			},
 			keyZoneSecurityKey: {
 				Type:      schema.TypeString,

--- a/internal/provider/resource_pullzone_test.go
+++ b/internal/provider/resource_pullzone_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"regexp"
 
 	"errors"
 	"fmt"
@@ -755,4 +756,23 @@ var pullZoneDiffIgnoredFields = map[string]struct{}{
 func pzDiff(t *testing.T, a, b interface{}) []string {
 	t.Helper()
 	return diffStructs(t, a, b, pullZoneDiffIgnoredFields)
+}
+
+func TestAccPullZone_OriginURLAndStorageZoneIDAreExclusive(t *testing.T) {
+	pzName := randPullZoneName()
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "bunny_pullzone" "testpz" {
+	name = "%s"
+	origin_url ="http://bunny.net"
+	storage_zone_id = 300
+}`, pzName),
+				ExpectError: regexp.MustCompile("only one of.*can be specified"),
+			},
+		},
+	})
 }


### PR DESCRIPTION
follow-up for: https://github.com/simplesurance/terraform-provider-bunny/pull/67
```
pullzone: define ExactlyOneOf only once

If ExactlyOneOf is defined on multiple attributes, for each one an error is
printed if more then one are set.

 Define ExactlyOneOf only for StorageZoneID, having one error is sufficient.

-------------------------------------------------------------------------------
docs: regenerate documentation

-------------------------------------------------------------------------------
changelog: add origin_url + storage_zone_id are mutually exclusive

-------------------------------------------------------------------------------
add pullzone testcase for defining storage_zone_id and origin_url

Add a testcase that ensures that defining storage_zone_id & origin_url of a
pull-zone results in an error.

-------------------------------------------------------------------------------
```