### PR TITLE
docs: improve storage zone origin_url field description

### DIFF
--- a/docs/resources/storagezone.md
+++ b/docs/resources/storagezone.md
@@ -29,7 +29,7 @@ resource "bunny_storagezone" "mysz" {
 ### Optional
 
 - `custom_404_file_path` (String) The path to the custom file that will be returned in a case of 404.
-- `origin_url` (String) The origin URL of the storage zone.
+- `origin_url` (String) A URL to which a request is proxied, if a file does not exist in the the storage zone.
 - `region` (String) The code of the main storage zone region (Possible values: DE, NY, LA, SG).
 - `replication_regions` (Set of String) The list of replication zones for the storage zone (Possible values: DE, NY, LA, SG, SYD). Replication zones cannot be removed once the zone has been created.
 - `rewrite_404_to_200` (Boolean) Rewrite 404 status code to 200 for URLs without extension.

--- a/internal/provider/resource_storagezone.go
+++ b/internal/provider/resource_storagezone.go
@@ -71,7 +71,7 @@ func resourceStorageZone() *schema.Resource {
 			// mutable properties
 			keyOriginURL: {
 				Type:        schema.TypeString,
-				Description: "The origin URL of the storage zone.",
+				Description: "A URL to which a request is proxied, if a file does not exist in the the storage zone.",
 				Optional:    true,
 			},
 			keyCustom404FilePath: {


### PR DESCRIPTION
Document the behavior of the origin_url field of storage zones as described at:
https://github.com/simplesurance/terraform-provider-bunny/issues/77#issuecomment-1160570977


Fixes #77 