### PR TITLE
storage zones: minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.9.1 (Unreleased)
+## 0.10.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* resource/storagezone: support SYD, UK, SE, BR regions
+* resource/storagezone: fail in planning phase if same primary and replication
+                        regions are specified
 
 ## 0.9.0 (Juni 30, 2022)
 

--- a/docs/resources/storagezone.md
+++ b/docs/resources/storagezone.md
@@ -30,8 +30,8 @@ resource "bunny_storagezone" "mysz" {
 
 - `custom_404_file_path` (String) The path to the custom file that will be returned in a case of 404.
 - `origin_url` (String) A URL to which a request is proxied, if a file does not exist in the the storage zone.
-- `region` (String) The code of the main storage zone region (Possible values: DE, NY, LA, SG).
-- `replication_regions` (Set of String) The list of replication zones for the storage zone (Possible values: DE, NY, LA, SG, SYD). Replication zones cannot be removed once the zone has been created.
+- `region` (String) The code of the main storage zone region (Possible values: DE, NY, LA, SG, SYD, UK, SE, BR).
+- `replication_regions` (Set of String) The list of replication zones for the storage zone (Possible values: DE, NY, LA, SG, SYD, UK, SE, BR). Replication zones cannot be removed once the zone has been created.
 - `rewrite_404_to_200` (Boolean) Rewrite 404 status code to 200 for URLs without extension.
 
 ### Read-Only

--- a/internal/provider/resource_storagezone.go
+++ b/internal/provider/resource_storagezone.go
@@ -243,14 +243,15 @@ func immutableReplicationRegionError(key string, removed []interface{}) error {
 	)
 }
 
-func creatingRegionWithoutReplicationRegionError(region string, allRegions []string) error {
-	const message = "'%s' region needs to have at least one replication region.\n" +
+func creatingRegionWithoutReplicationRegionError(region string, availRegions []string) error {
+	const message = "%q region needs to have at least one replication region.\n" +
 		"Please add one of the available replication region %s.\n"
-	return fmt.Errorf(message, region, allRegions)
+	return fmt.Errorf(message, region, strings.Join(availRegions, ", "))
 }
 
 func creatingRegionWithReplicationInSameRegionError(region string) error {
-	const message = "'%s' region selected as main and can't be used as replica.\n"
+	const message = "%q was specified as primary and replication region. " +
+		"The same region can not be both. Please specify different regions."
 	return fmt.Errorf(message, region)
 }
 

--- a/internal/provider/resource_storagezone.go
+++ b/internal/provider/resource_storagezone.go
@@ -408,7 +408,7 @@ func storageZoneFromResource(d *schema.ResourceData) *bunny.StorageZoneUpdateOpt
 }
 
 func removeValueFromStringSlice(values []string, value string) []string {
-	var result []string
+	result := make([]string, 0, len(values))
 
 	for _, v := range values {
 		if v != value {

--- a/internal/provider/resource_storagezone.go
+++ b/internal/provider/resource_storagezone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -57,21 +58,27 @@ func resourceStorageZone() *schema.Resource {
 				Required:    true,
 			},
 			keyRegion: {
-				Type:        schema.TypeString,
-				Description: "The code of the main storage zone region (Possible values: DE, NY, LA, SG, SYD, UK, SE, BR).",
-				Optional:    true,
-				Default:     "DE",
+				Type: schema.TypeString,
+				Description: fmt.Sprintf(
+					"The code of the main storage zone region (Possible values: %s).",
+					strings.Join(storageZoneAllRegions, ", "),
+				),
+				Optional: true,
+				Default:  "DE",
 				ValidateDiagFunc: validation.ToDiagFunc(
 					validation.StringInSlice(storageZoneAllRegions, false),
 				),
 			},
 			keyReplicationRegions: {
-				Type:        schema.TypeSet,
-				Description: "The list of replication zones for the storage zone (Possible values: DE, NY, LA, SG, SYD, UK, SE, BR). Replication zones cannot be removed once the zone has been created.",
+				Type: schema.TypeSet,
+				Description: fmt.Sprintf(
+					"The list of replication zones for the storage zone (Possible values: %s). Replication zones cannot be removed once the zone has been created.",
+					strings.Join(storageZoneAllRegions, ", "),
+				),
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateDiagFunc: validation.ToDiagFunc(
-						validation.StringInSlice([]string{"DE", "NY", "LA", "SG", "SYD", "UK", "SE", "BR"}, false),
+						validation.StringInSlice(storageZoneAllRegions, false),
 					),
 				},
 				Optional: true,

--- a/internal/provider/resource_storagezone_test.go
+++ b/internal/provider/resource_storagezone_test.go
@@ -288,10 +288,10 @@ resource "bunny_storagezone" "mytest1" {
 					*attrs.Region,
 					tfStrList(attrs.ReplicationRegions),
 				),
+				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(".*'SYD' region needs to have at least one replication region.*"),
 			},
 		},
-		CheckDestroy: checkStorageZoneNotExists(fullResourceName),
 	})
 }
 
@@ -321,10 +321,10 @@ resource "bunny_storagezone" "mytest1" {
 					*attrs.Region,
 					tfStrList(attrs.ReplicationRegions),
 				),
+				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(".*'SG' region selected as main and can't be used as replica.*"),
 			},
 		},
-		CheckDestroy: checkStorageZoneNotExists(fullResourceName),
 	})
 }
 

--- a/internal/provider/resource_storagezone_test.go
+++ b/internal/provider/resource_storagezone_test.go
@@ -289,7 +289,7 @@ resource "bunny_storagezone" "mytest1" {
 					tfStrList(attrs.ReplicationRegions),
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(".*'SYD' region needs to have at least one replication region.*"),
+				ExpectError: regexp.MustCompile(`.*"SYD" region needs to have at least one replication region.*`),
 			},
 		},
 	})
@@ -322,7 +322,7 @@ resource "bunny_storagezone" "mytest1" {
 					tfStrList(attrs.ReplicationRegions),
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(".*'SG' region selected as main and can't be used as replica.*"),
+				ExpectError: regexp.MustCompile(`.*"SG" was specified as primary and replication region.*`),
 			},
 		},
 	})

--- a/internal/provider/resource_storagezone_test.go
+++ b/internal/provider/resource_storagezone_test.go
@@ -263,15 +263,7 @@ resource "bunny_storagezone" "mytest1" {
 }
 
 func TestRegionsRequiringReplicationWithoutReplicationFails(t *testing.T) {
-	const resourceName = "mytest1"
-	const fullResourceName = "bunny_storagezone." + resourceName
 	storageZoneName := randResourceName()
-
-	attrs := bunny.StorageZone{
-		Name:               ptr.ToString(storageZoneName),
-		Region:             ptr.ToString("SYD"),
-		ReplicationRegions: []string{},
-	}
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
@@ -280,13 +272,10 @@ func TestRegionsRequiringReplicationWithoutReplicationFails(t *testing.T) {
 				Config: fmt.Sprintf(`
 resource "bunny_storagezone" "mytest1" {
 	name = "%s"
-	region = "%s"
-	replication_regions = %s
+	region = "SYD"
 }
 `,
 					storageZoneName,
-					*attrs.Region,
-					tfStrList(attrs.ReplicationRegions),
 				),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`.*"SYD" region needs to have at least one replication region.*`),
@@ -296,15 +285,7 @@ resource "bunny_storagezone" "mytest1" {
 }
 
 func TestReplicaRegionSameAsMainFails(t *testing.T) {
-	const resourceName = "mytest1"
-	const fullResourceName = "bunny_storagezone." + resourceName
 	storageZoneName := randResourceName()
-
-	attrs := bunny.StorageZone{
-		Name:               ptr.ToString(storageZoneName),
-		Region:             ptr.ToString("SG"),
-		ReplicationRegions: []string{"SG"},
-	}
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
@@ -313,13 +294,11 @@ func TestReplicaRegionSameAsMainFails(t *testing.T) {
 				Config: fmt.Sprintf(`
 resource "bunny_storagezone" "mytest1" {
 	name = "%s"
-	region = "%s"
-	replication_regions = %s
+	region = "SG"
+	replication_regions = ["SG"]
 }
 `,
 					storageZoneName,
-					*attrs.Region,
-					tfStrList(attrs.ReplicationRegions),
 				),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`.*"SG" was specified as primary and replication region.*`),


### PR DESCRIPTION
```
changelog: document support of new storage regions

-------------------------------------------------------------------------------
docs: regenerate documentation

-------------------------------------------------------------------------------
tests: simplify replication region testcases

- remove unused constants
- remove unnecessary attrs variable

-------------------------------------------------------------------------------
storagezone: prealloc slice

-------------------------------------------------------------------------------
storagezone: improve region related error messages

- remove array brackets from error message, separate supported regions with ", "
  instead
- change wording slightly
- remove trailing newline
- use double- instead of single quotes, as everywhere else

storagezone: rephrase primary & replication region are same error message

-------------------------------------------------------------------------------
storagezone: remove duplicate definitions of supported regions

Replace duplication definitions of the supported storage zone regions with using
the storageZoneAllRegions slice.

-------------------------------------------------------------------------------
tests/storagezone: change replication region validate tests to PlanOnly

The testcases should fail already during the planning phase, set PlanOnly to
true to ensure that and remove the CheckDestroy function.
Nothing needs to be destroyed because nothing can be created in the planning
phase.

-------------------------------------------------------------------------------
```